### PR TITLE
Datepicker does not hide

### DIFF
--- a/js/picker/Picker.js
+++ b/js/picker/Picker.js
@@ -202,9 +202,8 @@ export default class Picker {
     if (!this.active) {
       return;
     }
-    this.datepicker.exitEditMode();
-    this.element.classList.remove('active', 'block');
-    this.element.classList.add('active', 'block', 'hidden');
+    this.datepicker.exitEditMode();    
+    this.element.classList.toggle('active', 'block', 'hidden');
     this.active = false;
     triggerDatepickerEvent(this.datepicker, 'hide');
   }


### PR DESCRIPTION
The datepicker does not hide: adding classes `active` and  `block` with `hidden` does not hide the dp. 
Using `toggle` to add/remove classes.