### PR TITLE
Mark text-gray-500 as important for prev/next days in Dayview

### DIFF
--- a/js/picker/views/DaysView.js
+++ b/js/picker/views/DaysView.js
@@ -156,9 +156,9 @@ export default class DaysView extends View {
       el.textContent = date.getDate();
 
       if (current < this.first) {
-        classList.add('prev', 'text-gray-500', 'dark:text-white');
+        classList.add('prev', '!text-gray-500', 'dark:text-white');
       } else if (current > this.last) {
-        classList.add('next', 'text-gray-500', 'dark:text-white');
+        classList.add('next', '!text-gray-500', 'dark:text-white');
       }
       if (this.today === current) {
         classList.add('today', 'bg-gray-100', 'dark:bg-gray-600');


### PR DESCRIPTION
Currently, the datepicker does not make a distinction between days from previous and next months:
![image](https://github.com/themesberg/flowbite-datepicker/assets/4161158/0aa65541-d2c2-4d2e-876f-3d45c64832bc)

As you can see, the 29 and 30 from the previous month and the 1, 2, etc. from the next month have the same color as the days of the current month.

**The expected result is:**
![image](https://github.com/themesberg/flowbite-datepicker/assets/4161158/dd564775-f291-42d0-b5fc-42d8a7078c70)

I have solved this by simply adding `!` in front of the `text-gray-500` class which makes the distinction for previous and next month days.